### PR TITLE
Release 1.1.0

### DIFF
--- a/dist/components/Field.js
+++ b/dist/components/Field.js
@@ -51,7 +51,11 @@ var Field = function (_React$Component) {
   _createClass(Field, [{
     key: 'componentWillUpdate',
     value: function componentWillUpdate(nextProps) {
-      if (nextProps.value !== this.props.value && nextProps.value !== this.state.value) {
+      if (nextProps.passedValue !== this.props.passedValue) {
+        this.cancelBroadcast();
+        this.setState({ value: nextProps.passedValue });
+        this.finalValue = nextProps.passedValue;
+      } else if (nextProps.value !== this.props.value && nextProps.value !== this.state.value) {
         this.cancelBroadcast();
         this.setState({ value: nextProps.value });
         this.finalValue = nextProps.value;
@@ -65,6 +69,7 @@ var Field = function (_React$Component) {
   }, {
     key: 'shouldComponentUpdate',
     value: function shouldComponentUpdate(nextProps) {
+      if (nextProps.passedValue !== this.props.passedValue) return true;
       if (nextProps.value !== this.state.value) return true;
       if (this.state.value !== this.finalValue) return true;
       if (this.props.match !== nextProps.match) return true;
@@ -151,6 +156,7 @@ var Field = function (_React$Component) {
 
 Field.propTypes = {
   value: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.number]),
+  passedValue: _react2.default.PropTypes.oneOfType([_react2.default.PropTypes.string, _react2.default.PropTypes.number]),
   name: _react2.default.PropTypes.string,
   onChange: _react2.default.PropTypes.func,
   onFocus: _react2.default.PropTypes.func,
@@ -163,6 +169,7 @@ Field.propTypes = {
 
 Field.defaultProps = {
   value: '',
+  passedValue: '',
   name: '',
   onChange: undefined,
   onFocus: undefined,

--- a/dist/components/Field.js
+++ b/dist/components/Field.js
@@ -18,6 +18,8 @@ var _utilities = require('../helpers/utilities');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -118,6 +120,8 @@ var Field = function (_React$Component) {
   }, {
     key: 'render',
     value: function render() {
+      var _this2 = this;
+
       var childCount = _react2.default.Children.count(this.props.children);
       var inputProps = {
         name: this.props.name,
@@ -143,8 +147,16 @@ var Field = function (_React$Component) {
         'div',
         null,
         _react2.default.Children.map(this.props.children, function (child) {
-          return (0, _utilities.mapPropsToChild)(child, 'input', function () {
-            return inputProps;
+          return (0, _utilities.mapPropsToChild)(child, {
+            input: function input() {
+              return inputProps;
+            },
+            valid: function valid() {
+              return (0, _utilities.makePropsForStatus)('valid', _defineProperty({}, _this2.props.name, { valid: _this2.state.valid }));
+            },
+            pristine: function pristine() {
+              return (0, _utilities.makePropsForStatus)('pristine', _defineProperty({}, _this2.props.name, { pristine: _this2.state.pristine }));
+            }
           });
         })
       );

--- a/dist/components/Form.js
+++ b/dist/components/Form.js
@@ -79,8 +79,15 @@ var Form = function (_React$Component) {
         'form',
         { onSubmit: this.onSubmit },
         _react2.default.Children.map(this.props.children, function (child) {
-          return (0, _utilities.mapPropsToChild)(child, 'Field', function (grandChild) {
-            return (0, _utilities.makeFieldProps)(grandChild, _this3.onFieldChange, _this3.state);
+          return (0, _utilities.mapPropsToChild)(child, { Field: function Field(grandChild) {
+              return (0, _utilities.makeFieldProps)(grandChild, _this3.onFieldChange, _this3.state);
+            },
+            pristine: function pristine() {
+              return (0, _utilities.makePropsForStatus)('pristine', _this3.state);
+            },
+            valid: function valid() {
+              return (0, _utilities.makePropsForStatus)('valid', _this3.state);
+            }
           });
         })
       );

--- a/dist/helpers/utilities.js
+++ b/dist/helpers/utilities.js
@@ -119,7 +119,11 @@ function getValuesOf() {
 function makeFieldProps(child, onChange, state) {
   if (typeof child.type === 'function' && child.type.name === 'Field') {
     var name = child.props.name;
-    return { name: name, onChange: onChange, key: name, value: state[name] ? state[name].value : null };
+    var props = { name: name, onChange: onChange, key: name, value: state[name] ? state[name].value : null };
+
+    if (child.props.value !== undefined) props.passedValue = child.props.value;
+
+    return props;
   }
   return null;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-formulize",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A simple form validation library for React.js which wires up custom, controlled inputs through a declarative API.",
   "main": "dist/index",
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,7 @@ React-formulize can be used to both quickly compose forms or add validation to e
   2. A `Field` component can wrap (nested JSX) an `input` element (or a fragment containing an `input`) and control its underlying state automatically.
   3. Pass validator props to the `Field` components. A `Field` component will keep track of its own validity.
   4. Pass an `onSubmit` handler to `Form` in order to interact with the submission event. The callback will be passed a clone of the `Form`'s state.
+  5. Pass `valid` and `pristine` props to any nested child components in either a `Form` or `Field` component. These components will receive information about the `Form`'s status in the format of `${fieldName}_${statusType}` (e.g. name_valid & email_pristine).
 
 #### Example: Composing A New Form With Custom Input Component(s)
 ```javascript  
@@ -112,8 +113,10 @@ The `Form` component is a stateful higher-order-component which wraps presentati
 The `Form` component will behave as follows with respect to its children:
 
   1. Any `Field` tag will be passed the state associated with the `Field`'s name (`Form.state[child.props.name]`).
-  2. Any other component or element will be rendered with the props it would otherwise be passed.
-  3. Upon submission, `Form` will pass its `onSubmit` callback a clone of its current state.
+  2. Any component with a `valid` prop will be passed props stating the validity for all `Field`s in the `Form` (e.g. name_valid).  
+  3. Any component with a `pristine` prop will be passed a props stating the pristine state for all `Field`s in the `Form` (e.g. email_pristine).  
+  4. Any other component or element will be rendered with the props it would otherwise be passed.
+  5. Upon submission, `Form` will pass its `onSubmit` callback a clone of its current state.
 
 *Note:* The `Form` component should be passed an `onSubmit` handler if you want to interact with the submission event!
 
@@ -184,7 +187,9 @@ The `Field` component will behave as follows with respect to its children:
   2. Any `input` tag will be passed `name`, `type`, `value`, and `onChange` props.  
   3. If only a single direct child is passed to `Field`, it will be passed all of the relevant input props.  
   4. If multiple `input` tags are nested in a single `Field`, they would all share a single state (not recommended).  
-  
+  5. Any component with a `valid` prop will be passed a prop stating the `Field`'s validity (e.g. name_valid).  
+  6. Any component with a `pristine` prop will be passed a prop stating the `Field`'s pristine state (e.g. email_pristine).  
+
 *Note:* Only one input element should be nested inside of a `Field` tag (see #4 above).
 
 ### Props

--- a/readme.md
+++ b/readme.md
@@ -196,7 +196,7 @@ The `Field` component will behave as follows with respect to its children:
 #### `props.value = value`
 > @param {String} [value=''] - The value of the wrapped input component.
 
-  This property is used to control the value of the wrapped input component.  
+  This property is used to control the value of the wrapped input component. If set on the field, this value will be used everytime it is detected as a new (changed) value. This is useful in cases where you need to programmatically populate the field's value (but still allow the input to be edited).  
 
 #### `props.type = type`
 > @param {String} [type='text'] - The input type of the wrapped input element.

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-react-formulize [![Build Status](https://travis-ci.org/clocasto/react-formulize.svg?branch=master)](https://travis-ci.org/clocasto/react-formulize) [![Coverage Status](https://coveralls.io/repos/github/clocasto/react-formulize/badge.svg?branch=master&version=1_0_0)](https://coveralls.io/github/clocasto/react-formulize?branch=master&version=1_0_0)
+react-formulize [![Build Status](https://travis-ci.org/clocasto/react-formulize.svg?branch=master)](https://travis-ci.org/clocasto/react-formulize) [![Coverage Status](https://coveralls.io/repos/github/clocasto/react-formulize/badge.svg?branch=master&version=1_1_0)](https://coveralls.io/github/clocasto/react-formulize?branch=master&version=1_1_0)
 =========
 
 React-formulize is a simple form validation library for React.js which wires up custom, controlled inputs through a declarative API. The library strives to be minimal, and as such, does most component communication implicity. The end result is a legible form which clearly states the rules of its behavior.
@@ -304,4 +304,5 @@ MIT (See license.txt)
 
 ## <a href="release-history"></a>Release History
 
+* [1.1.0](https://github.com/clocasto/react-formulize/pull/32) (Current)
 * [1.0.0](https://github.com/clocasto/react-formulize/pull/25)

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -29,7 +29,11 @@ const Field = class extends React.Component {
   }
 
   componentWillUpdate(nextProps) {
-    if ((nextProps.value !== this.props.value) && (nextProps.value !== this.state.value)) {
+    if (nextProps.passedValue !== this.props.passedValue) {
+      this.cancelBroadcast();
+      this.setState({ value: nextProps.passedValue });
+      this.finalValue = nextProps.passedValue;
+    } else if (nextProps.value !== this.props.value && nextProps.value !== this.state.value) {
       this.cancelBroadcast();
       this.setState({ value: nextProps.value });
       this.finalValue = nextProps.value;
@@ -42,6 +46,7 @@ const Field = class extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
+    if (nextProps.passedValue !== this.props.passedValue) return true;
     if (nextProps.value !== this.state.value) return true;
     if (this.state.value !== this.finalValue) return true;
     if (this.props.match !== nextProps.match) return true;
@@ -115,6 +120,7 @@ const Field = class extends React.Component {
 
 Field.propTypes = {
   value: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
+  passedValue: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]),
   name: React.PropTypes.string,
   onChange: React.PropTypes.func,
   onFocus: React.PropTypes.func,
@@ -131,6 +137,7 @@ Field.propTypes = {
 
 Field.defaultProps = {
   value: '',
+  passedValue: '',
   name: '',
   onChange: undefined,
   onFocus: undefined,

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -6,6 +6,7 @@ import {
   updateValidators,
   getValuesOf,
   mapPropsToChild,
+  makePropsForStatus,
 } from '../helpers/utilities';
 
 const Field = class extends React.Component {
@@ -112,7 +113,13 @@ const Field = class extends React.Component {
     return (
       <div>
         {React.Children
-          .map(this.props.children, child => mapPropsToChild(child, 'input', () => inputProps))}
+          .map(this.props.children, child => mapPropsToChild(child, {
+            input: () => inputProps,
+            valid: () => makePropsForStatus('valid', { [this.props.name]: { valid: this.state.valid } }),
+            pristine: () => makePropsForStatus('pristine', {
+              [this.props.name]: { pristine: this.state.pristine },
+            }),
+          }))}
       </div>
     );
   }

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { addFieldsToState, mapPropsToChild, makeFieldProps } from '../helpers/utilities';
+import {
+  addFieldsToState,
+  mapPropsToChild,
+  makeFieldProps,
+  makePropsForStatus,
+} from '../helpers/utilities';
 
 const Form = class extends React.Component {
   constructor(props) {
@@ -37,9 +42,12 @@ const Form = class extends React.Component {
           .map(this.props.children, child =>
             mapPropsToChild(
               child,
-              'Field',
-              grandChild => makeFieldProps(grandChild, this.onFieldChange, this.state),
-        ))}
+              { Field: grandChild => makeFieldProps(grandChild, this.onFieldChange, this.state),
+                pristine: () => makePropsForStatus('pristine', this.state),
+                valid: () => makePropsForStatus('valid', this.state),
+              },
+            ),
+        )}
       </form>
     );
   }

--- a/src/helpers/utilities.jsx
+++ b/src/helpers/utilities.jsx
@@ -36,13 +36,19 @@ export function isValid(value, validators) {
   }, true);
 }
 
+export function getValuesOf(obj = {}) {
+  return Object.keys(obj).map(key => obj[key]);
+}
+
 export function buildStateForField(fieldProps) {
-  const { value, valid, pristine } = fieldProps;
-  const newState = { value: '', valid: false, pristine: true };
+  const { value } = fieldProps;
+  const newState = {
+    value: '',
+    valid: isValid(value, getValuesOf(assembleValidators(fieldProps))),
+    pristine: true,
+  };
 
   if (value !== undefined) Object.assign(newState, { value });
-  if (valid !== undefined) Object.assign(newState, { valid });
-  if (pristine !== undefined) Object.assign(newState, { pristine });
   return newState;
 }
 
@@ -63,10 +69,6 @@ export function addFieldsToState(component, child, mounted = false) {
   }
 }
 
-export function getValuesOf(obj = {}) {
-  return Object.keys(obj).map(key => obj[key]);
-}
-
 export function makeFieldProps(child, onChange, state) {
   if (typeof child.type === 'function' && child.type.name === 'Field') {
     const name = child.props.name;
@@ -79,14 +81,40 @@ export function makeFieldProps(child, onChange, state) {
   return null;
 }
 
-export function mapPropsToChild(child, type, propFunction) {
-  if (child.type === type || (typeof child.type === 'function' && child.type.name === type)) {
-    return React.cloneElement(child, propFunction(child));
+export function makePropsForStatus(status, state) {
+  return Object.keys(state).reduce((props, field) => {
+    if (Object.prototype.hasOwnProperty.call(state[field], status)) {
+      return { ...props, [`${field}_${status}`]: state[field][status] };
+    }
+    return props;
+  }, {});
+}
+
+export function mapPropsToChild(child, childPropsMap) {
+  const type = (typeof child.type === 'function') ? child.type.name : child.type;
+  const childProps = {};
+  let newChildren;
+
+  if (child.props) {
+    if (childPropsMap.valid && child.props.valid) {
+      Object.assign(childProps, childPropsMap.valid());
+    }
+    if (childPropsMap.pristine && child.props.pristine) {
+      Object.assign(childProps, childPropsMap.pristine());
+    }
+    if (child.props.children) {
+      newChildren = React.Children
+        .map(child.props.children, nestedChild => mapPropsToChild(nestedChild, childPropsMap));
+    }
   }
-  if (child.props && child.props.children) {
-    const newChildren = React.Children.map(child.props.children, nestedChild => (
-      mapPropsToChild(nestedChild, type, propFunction)));
-    return React.cloneElement(child, null, newChildren);
+
+  if (childPropsMap.Field && type === 'Field') {
+    return React.cloneElement(child, { ...childPropsMap.Field(child), ...childProps }, newChildren);
   }
-  return child;
+  if (childPropsMap.input && type === 'input') {
+    return React.cloneElement(child, { ...childPropsMap.input(child), ...childProps }, newChildren);
+  }
+
+  return (Object.keys(childProps).length || newChildren) ?
+    React.cloneElement(child, childProps, newChildren) : child;
 }

--- a/src/helpers/utilities.jsx
+++ b/src/helpers/utilities.jsx
@@ -70,7 +70,11 @@ export function getValuesOf(obj = {}) {
 export function makeFieldProps(child, onChange, state) {
   if (typeof child.type === 'function' && child.type.name === 'Field') {
     const name = child.props.name;
-    return { name, onChange, key: name, value: state[name] ? state[name].value : null };
+    const props = { name, onChange, key: name, value: state[name] ? state[name].value : null };
+
+    if (child.props.value !== undefined) props.passedValue = child.props.value;
+
+    return props;
   }
   return null;
 }

--- a/tests/components/Field.spec.js
+++ b/tests/components/Field.spec.js
@@ -128,6 +128,57 @@ describe('<Field /> Higher-Order-Component', () => {
     });
   });
 
+  describe('Passing down status', () => {
+    const TestComponent = () => <span>Test!</span>;
+    let wrapper;
+    let first;
+    let second;
+    let third;
+
+    beforeEach('Set up a basic form with testComponents in different configurations', () => {
+      wrapper = mount(
+        <Field name="name" value="" required>
+          <input />
+          <span>Hi There!</span>
+          <div>
+            <TestComponent valid />
+          </div>
+          <TestComponent pristine />
+          <TestComponent valid pristine>
+            <span>Hi There!</span>
+          </TestComponent>
+        </Field>,
+      );
+      first = wrapper.find(TestComponent).first();
+      second = wrapper.find(TestComponent).at(1);
+      third = wrapper.find(TestComponent).last();
+    });
+
+    it('passes validity information down to components with a `valid` prop', () => {
+      expect(first.props()).to.have.property('name_valid', false);
+
+      expect(second.props()).to.not.have.property('name_valid');
+    });
+
+    it('passes pristine information down to components with a `pristine` prop', () => {
+      expect(second.props()).to.have.property('name_pristine', true);
+
+      updateInput(wrapper, 'secondValue');
+      expect(second.props()).to.have.property('name_pristine', false);
+
+      expect(first.props()).to.not.have.property('name_pristine');
+    });
+
+    it('passes valid and pristine info down to components with flags', () => {
+      expect(third.props()).to.have.property('name_valid', false);
+      expect(third.props()).to.have.property('name_pristine', true);
+
+      updateInput(wrapper, 'Test Name');
+      expect(third.props()).to.have.property('name_pristine', false);
+      expect(third.props()).to.have.property('name_valid', true);
+    });
+  });
+
   describe('`Field` lifecycle method tests', () => {
     let wrapper;
     let shouldUpdateSpy;

--- a/tests/components/Form.spec.js
+++ b/tests/components/Form.spec.js
@@ -145,4 +145,35 @@ describe('<Form /> Higher-Order-Component', () => {
       Form.prototype.reset.restore();
     });
   });
+
+  describe('Passes down a value prop that changed', () => {
+    let wrapper;
+    let fieldComponent;
+    const cache = { value: 'firstValue' };
+    const retrieveCacheValue = () => cache.value;
+    const FieldWithValue = () => <Field name="nameField" value={retrieveCacheValue()} />;
+
+    before('Assemble a custom input element', () => {
+      wrapper = mount(
+        <Form>
+          {FieldWithValue()}
+        </Form>);
+      fieldComponent = wrapper.find(Field);
+    });
+
+    it('Should update its value when passed a new value prop', () => {
+      expect(fieldComponent.props()).to.have.property('name', 'nameField');
+      expect(fieldComponent.props()).to.have.property('value', 'firstValue');
+      expect(fieldComponent.props()).to.have.property('passedValue', 'firstValue');
+
+      // Update the cache's value;
+      cache.value = 'secondValue';
+      wrapper.setProps({ children: FieldWithValue() });
+
+      expect(fieldComponent.props()).to.have.property('name', 'nameField');
+      expect(fieldComponent.props()).to.have.property('value', 'firstValue');
+      expect(fieldComponent.props()).to.have.property('passedValue', 'secondValue');
+      expect(wrapper.state().nameField).to.eql({ value: 'firstValue', valid: false, pristine: true });
+    });
+  });
 });


### PR DESCRIPTION
- `Form` component will now set its initial state differently. Rather than assuming all `Field`s start invalid, `Form` will run the specified validators on the `Field`s that it finds and use the resulting initial validity. Updated tests to reflect this.
- Refactored `mapPropsToChild`. It now checks manually for a certain set of props of components, but its function signature is easier to work with.
- `Field` components will now respect a dynamic `value` prop passed to them throughout their lifetime (i.e. `<Field value={props.aValueThatMightChange} />`). Previously this would only be respected during initial mounting,  but now `props.value` will be respected when it is detected to have changed (meaning initially *and* on update). 