### PR TITLE
Bug #33

### DIFF
--- a/dist/components/Field.js
+++ b/dist/components/Field.js
@@ -55,13 +55,11 @@ var Field = function (_React$Component) {
     key: 'componentWillUpdate',
     value: function componentWillUpdate(nextProps) {
       if (nextProps.passedValue !== this.props.passedValue) {
-        this.cancelBroadcast();
+        this.cancelBroadcast(nextProps.passedValue);
         this.setState({ value: nextProps.passedValue }, this.debouncedBroadcastChange);
-        this.finalValue = nextProps.passedValue;
       } else if (nextProps.value !== this.props.value && nextProps.value !== this.state.value) {
-        this.cancelBroadcast();
+        this.cancelBroadcast(nextProps.value);
         this.setState({ value: nextProps.value });
-        this.finalValue = nextProps.value;
       }
 
       if (this.props.match !== nextProps.match) {
@@ -113,10 +111,12 @@ var Field = function (_React$Component) {
   }, {
     key: 'cancelBroadcast',
     value: function cancelBroadcast() {
+      var newFinalValue = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
+
       if (this.debouncedBroadcastChange.cancel) {
         this.debouncedBroadcastChange.cancel();
-        this.finalValue = null;
       }
+      this.finalValue = newFinalValue;
     }
   }, {
     key: 'render',

--- a/dist/components/Field.js
+++ b/dist/components/Field.js
@@ -34,13 +34,14 @@ var Field = function (_React$Component) {
 
     var _this = _possibleConstructorReturn(this, (Field.__proto__ || Object.getPrototypeOf(Field)).call(this, props));
 
+    var validators = (0, _utilities.assembleValidators)(props);
+
     _this.state = {
-      value: props.value || '',
-      valid: false,
+      value: props.value,
+      validators: validators,
+      valid: (0, _utilities.isValid)(props.value, (0, _utilities.getValuesOf)(validators)),
       pristine: true,
-      debounce: Math.floor(Math.pow(Math.pow(+props.debounce, 2), 0.5)) || 0, //eslint-disable-line
-      validators: (0, _utilities.assembleValidators)(props)
-    };
+      debounce: Math.floor(Math.pow(Math.pow(+props.debounce, 2), 0.5)) || 0 };
     _this.finalValue = null;
 
     _this.onChange = _this.onChange.bind(_this);

--- a/dist/components/Field.js
+++ b/dist/components/Field.js
@@ -55,7 +55,7 @@ var Field = function (_React$Component) {
     value: function componentWillUpdate(nextProps) {
       if (nextProps.passedValue !== this.props.passedValue) {
         this.cancelBroadcast();
-        this.setState({ value: nextProps.passedValue });
+        this.setState({ value: nextProps.passedValue }, this.debouncedBroadcastChange);
         this.finalValue = nextProps.passedValue;
       } else if (nextProps.value !== this.props.value && nextProps.value !== this.state.value) {
         this.cancelBroadcast();

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -13,12 +13,14 @@ const Field = class extends React.Component {
   constructor(props) {
     super(props);
 
+    const validators = assembleValidators(props);
+
     this.state = {
-      value: props.value || '',
-      valid: false,
+      value: props.value,
+      validators,
+      valid: isValid(props.value, getValuesOf(validators)),
       pristine: true,
       debounce: Math.floor(Math.pow(Math.pow(+props.debounce, 2), 0.5)) || 0, //eslint-disable-line
-      validators: assembleValidators(props),
     };
     this.finalValue = null;
 

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -16,8 +16,8 @@ const Field = class extends React.Component {
     const validators = assembleValidators(props);
 
     this.state = {
-      value: props.value,
       validators,
+      value: props.value,
       valid: isValid(props.value, getValuesOf(validators)),
       pristine: true,
       debounce: Math.floor(Math.pow(Math.pow(+props.debounce, 2), 0.5)) || 0, //eslint-disable-line

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -33,13 +33,11 @@ const Field = class extends React.Component {
 
   componentWillUpdate(nextProps) {
     if (nextProps.passedValue !== this.props.passedValue) {
-      this.cancelBroadcast();
+      this.cancelBroadcast(nextProps.passedValue);
       this.setState({ value: nextProps.passedValue }, this.debouncedBroadcastChange);
-      this.finalValue = nextProps.passedValue;
     } else if (nextProps.value !== this.props.value && nextProps.value !== this.state.value) {
-      this.cancelBroadcast();
+      this.cancelBroadcast(nextProps.value);
       this.setState({ value: nextProps.value });
-      this.finalValue = nextProps.value;
     }
 
     if (this.props.match !== nextProps.match) {
@@ -85,11 +83,11 @@ const Field = class extends React.Component {
     }
   }
 
-  cancelBroadcast() {
+  cancelBroadcast(newFinalValue = null) {
     if (this.debouncedBroadcastChange.cancel) {
       this.debouncedBroadcastChange.cancel();
-      this.finalValue = null;
     }
+    this.finalValue = newFinalValue;
   }
 
   render() {

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -32,7 +32,7 @@ const Field = class extends React.Component {
   componentWillUpdate(nextProps) {
     if (nextProps.passedValue !== this.props.passedValue) {
       this.cancelBroadcast();
-      this.setState({ value: nextProps.passedValue });
+      this.setState({ value: nextProps.passedValue }, this.debouncedBroadcastChange);
       this.finalValue = nextProps.passedValue;
     } else if (nextProps.value !== this.props.value && nextProps.value !== this.state.value) {
       this.cancelBroadcast();

--- a/tests/components/Form.spec.js
+++ b/tests/components/Form.spec.js
@@ -247,7 +247,7 @@ describe('<Form /> Higher-Order-Component', () => {
       expect(fieldComponent.props()).to.have.property('name', 'nameField');
       expect(fieldComponent.props()).to.have.property('value', 'secondValue');
       expect(fieldComponent.props()).to.have.property('passedValue', 'secondValue');
-      expect(wrapper.state().nameField).to.eql({ value: 'secondValue', valid: false, pristine: true });
+      expect(wrapper.state().nameField).to.eql({ value: 'secondValue', valid: true, pristine: true });
     });
   });
 });

--- a/tests/components/Form.spec.js
+++ b/tests/components/Form.spec.js
@@ -245,9 +245,9 @@ describe('<Form /> Higher-Order-Component', () => {
       wrapper.setProps({ children: FieldWithValue() });
 
       expect(fieldComponent.props()).to.have.property('name', 'nameField');
-      expect(fieldComponent.props()).to.have.property('value', 'firstValue');
+      expect(fieldComponent.props()).to.have.property('value', 'secondValue');
       expect(fieldComponent.props()).to.have.property('passedValue', 'secondValue');
-      expect(wrapper.state().nameField).to.eql({ value: 'firstValue', valid: true, pristine: true });
+      expect(wrapper.state().nameField).to.eql({ value: 'secondValue', valid: false, pristine: true });
     });
   });
 });

--- a/tests/utilities/validators.spec.js
+++ b/tests/utilities/validators.spec.js
@@ -239,7 +239,7 @@ describe('Validator Functionality', () => {
     });
 
     it('is properly used by a `Field` component to validate', () => {
-      expect(wrapper.state()).to.have.property('valid', false);
+      expect(wrapper.state()).to.have.property('valid', true);
       expect(wrapper.state()).to.have.property('value', '');
 
       updateInput(wrapper, 'Test Input');
@@ -284,7 +284,7 @@ describe('Validator Functionality', () => {
 
     it('is properly used by a `Field` component to validate', () => {
       expect(wrapper.state()).to.have.property('value', '');
-      expect(wrapper.state()).to.have.property('valid', false);
+      expect(wrapper.state()).to.have.property('valid', true);
 
       updateInput(wrapper, '12345\t12345 12345');
       expect(wrapper.state()).to.have.property('value', '12345\t12345 12345');


### PR DESCRIPTION
- Refactored `Field.prototype.cancelBroadcast` to accept a new finalValue to set
- `Field` now broadcasts a change when it sets its internal value based on `props.value`
- `Field` now sets its initial validity by running the provided validators