### PR TITLE
Release 1.1.1

### DIFF
--- a/dist/components/Field.js
+++ b/dist/components/Field.js
@@ -34,13 +34,14 @@ var Field = function (_React$Component) {
 
     var _this = _possibleConstructorReturn(this, (Field.__proto__ || Object.getPrototypeOf(Field)).call(this, props));
 
+    var validators = (0, _utilities.assembleValidators)(props);
+
     _this.state = {
-      value: props.value || '',
-      valid: false,
+      value: props.value,
+      validators: validators,
+      valid: (0, _utilities.isValid)(props.value, (0, _utilities.getValuesOf)(validators)),
       pristine: true,
-      debounce: Math.floor(Math.pow(Math.pow(+props.debounce, 2), 0.5)) || 0, //eslint-disable-line
-      validators: (0, _utilities.assembleValidators)(props)
-    };
+      debounce: Math.floor(Math.pow(Math.pow(+props.debounce, 2), 0.5)) || 0 };
     _this.finalValue = null;
 
     _this.onChange = _this.onChange.bind(_this);
@@ -54,13 +55,11 @@ var Field = function (_React$Component) {
     key: 'componentWillUpdate',
     value: function componentWillUpdate(nextProps) {
       if (nextProps.passedValue !== this.props.passedValue) {
-        this.cancelBroadcast();
-        this.setState({ value: nextProps.passedValue });
-        this.finalValue = nextProps.passedValue;
+        this.cancelBroadcast(nextProps.passedValue);
+        this.setState({ value: nextProps.passedValue }, this.debouncedBroadcastChange);
       } else if (nextProps.value !== this.props.value && nextProps.value !== this.state.value) {
-        this.cancelBroadcast();
+        this.cancelBroadcast(nextProps.value);
         this.setState({ value: nextProps.value });
-        this.finalValue = nextProps.value;
       }
 
       if (this.props.match !== nextProps.match) {
@@ -112,10 +111,12 @@ var Field = function (_React$Component) {
   }, {
     key: 'cancelBroadcast',
     value: function cancelBroadcast() {
+      var newFinalValue = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
+
       if (this.debouncedBroadcastChange.cancel) {
         this.debouncedBroadcastChange.cancel();
-        this.finalValue = null;
       }
+      this.finalValue = newFinalValue;
     }
   }, {
     key: 'render',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-formulize",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A simple form validation library for React.js which wires up custom, controlled inputs through a declarative API.",
   "main": "dist/index",
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-react-formulize [![Build Status](https://travis-ci.org/clocasto/react-formulize.svg?branch=master)](https://travis-ci.org/clocasto/react-formulize) [![Coverage Status](https://coveralls.io/repos/github/clocasto/react-formulize/badge.svg?branch=master&version=1_1_0)](https://coveralls.io/github/clocasto/react-formulize?branch=master&version=1_1_0)
+react-formulize [![Build Status](https://travis-ci.org/clocasto/react-formulize.svg?branch=master)](https://travis-ci.org/clocasto/react-formulize) [![Coverage Status](https://coveralls.io/repos/github/clocasto/react-formulize/badge.svg?branch=master&version=1_1_1)](https://coveralls.io/github/clocasto/react-formulize?branch=master&version=1_1_1)
 =========
 
 React-formulize is a simple form validation library for React.js which wires up custom, controlled inputs through a declarative API. The library strives to be minimal, and as such, does most component communication implicity. The end result is a legible form which clearly states the rules of its behavior.
@@ -304,5 +304,6 @@ MIT (See license.txt)
 
 ## <a href="release-history"></a>Release History
 
-* [1.1.0](https://github.com/clocasto/react-formulize/pull/32) (Current)
+* [1.1.1](https://github.com/clocasto/react-formulize/pull/35) (Current)
+* [1.1.0](https://github.com/clocasto/react-formulize/pull/32)
 * [1.0.0](https://github.com/clocasto/react-formulize/pull/25)

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -13,12 +13,14 @@ const Field = class extends React.Component {
   constructor(props) {
     super(props);
 
+    const validators = assembleValidators(props);
+
     this.state = {
-      value: props.value || '',
-      valid: false,
+      validators,
+      value: props.value,
+      valid: isValid(props.value, getValuesOf(validators)),
       pristine: true,
       debounce: Math.floor(Math.pow(Math.pow(+props.debounce, 2), 0.5)) || 0, //eslint-disable-line
-      validators: assembleValidators(props),
     };
     this.finalValue = null;
 
@@ -31,13 +33,11 @@ const Field = class extends React.Component {
 
   componentWillUpdate(nextProps) {
     if (nextProps.passedValue !== this.props.passedValue) {
-      this.cancelBroadcast();
-      this.setState({ value: nextProps.passedValue });
-      this.finalValue = nextProps.passedValue;
+      this.cancelBroadcast(nextProps.passedValue);
+      this.setState({ value: nextProps.passedValue }, this.debouncedBroadcastChange);
     } else if (nextProps.value !== this.props.value && nextProps.value !== this.state.value) {
-      this.cancelBroadcast();
+      this.cancelBroadcast(nextProps.value);
       this.setState({ value: nextProps.value });
-      this.finalValue = nextProps.value;
     }
 
     if (this.props.match !== nextProps.match) {
@@ -83,11 +83,11 @@ const Field = class extends React.Component {
     }
   }
 
-  cancelBroadcast() {
+  cancelBroadcast(newFinalValue = null) {
     if (this.debouncedBroadcastChange.cancel) {
       this.debouncedBroadcastChange.cancel();
-      this.finalValue = null;
     }
+    this.finalValue = newFinalValue;
   }
 
   render() {

--- a/tests/components/Form.spec.js
+++ b/tests/components/Form.spec.js
@@ -245,9 +245,9 @@ describe('<Form /> Higher-Order-Component', () => {
       wrapper.setProps({ children: FieldWithValue() });
 
       expect(fieldComponent.props()).to.have.property('name', 'nameField');
-      expect(fieldComponent.props()).to.have.property('value', 'firstValue');
+      expect(fieldComponent.props()).to.have.property('value', 'secondValue');
       expect(fieldComponent.props()).to.have.property('passedValue', 'secondValue');
-      expect(wrapper.state().nameField).to.eql({ value: 'firstValue', valid: true, pristine: true });
+      expect(wrapper.state().nameField).to.eql({ value: 'secondValue', valid: true, pristine: true });
     });
   });
 });

--- a/tests/utilities/validators.spec.js
+++ b/tests/utilities/validators.spec.js
@@ -239,7 +239,7 @@ describe('Validator Functionality', () => {
     });
 
     it('is properly used by a `Field` component to validate', () => {
-      expect(wrapper.state()).to.have.property('valid', false);
+      expect(wrapper.state()).to.have.property('valid', true);
       expect(wrapper.state()).to.have.property('value', '');
 
       updateInput(wrapper, 'Test Input');
@@ -284,7 +284,7 @@ describe('Validator Functionality', () => {
 
     it('is properly used by a `Field` component to validate', () => {
       expect(wrapper.state()).to.have.property('value', '');
-      expect(wrapper.state()).to.have.property('valid', false);
+      expect(wrapper.state()).to.have.property('valid', true);
 
       updateInput(wrapper, '12345\t12345 12345');
       expect(wrapper.state()).to.have.property('value', '12345\t12345 12345');


### PR DESCRIPTION
- Refactored `Field.prototype.cancelBroadcast` to accept a new finalValue to set
- `Field` now broadcasts a change when it sets its internal value based on `props.value`
- `Field` now sets its initial validity by running the provided validators