### PR TITLE
Release 1.2.0

### DIFF
--- a/dist/components/Field.js
+++ b/dist/components/Field.js
@@ -37,8 +37,8 @@ var Field = function (_React$Component) {
     var validators = (0, _utilities.assembleValidators)(props);
 
     _this.state = {
-      value: props.value,
       validators: validators,
+      value: props.value,
       valid: (0, _utilities.isValid)(props.value, (0, _utilities.getValuesOf)(validators)),
       pristine: true,
       debounce: Math.floor(Math.pow(Math.pow(+props.debounce, 2), 0.5)) || 0 };

--- a/dist/helpers/utilities.js
+++ b/dist/helpers/utilities.js
@@ -143,29 +143,28 @@ function makePropsForStatus(status, state) {
 
 function mapPropsToChild(child, childPropsMap) {
   var type = typeof child.type === 'function' ? child.type.name : child.type;
-  var childProps = {};
+  var childProps = void 0;
   var newChildren = void 0;
 
-  if (child.props) {
-    if (childPropsMap.valid && child.props.valid) {
-      Object.assign(childProps, childPropsMap.valid());
-    }
-    if (childPropsMap.pristine && child.props.pristine) {
-      Object.assign(childProps, childPropsMap.pristine());
-    }
-    if (child.props.children) {
-      newChildren = _react2.default.Children.map(child.props.children, function (nestedChild) {
-        return mapPropsToChild(nestedChild, childPropsMap);
-      });
-    }
-  }
+  if (!child.props) return child;
 
+  if (childPropsMap.valid && child.props.valid) {
+    childProps = _extends({}, childProps, childPropsMap.valid());
+  }
+  if (childPropsMap.pristine && child.props.pristine) {
+    childProps = _extends({}, childProps, childPropsMap.pristine());
+  }
+  if (childPropsMap.input && (type === 'input' || child.props.input)) {
+    childProps = _extends({}, childProps, childPropsMap.input(child));
+  }
   if (childPropsMap.Field && type === 'Field') {
-    return _react2.default.cloneElement(child, _extends({}, childPropsMap.Field(child), childProps), newChildren);
+    childProps = _extends({}, childProps, childPropsMap.Field(child));
   }
-  if (childPropsMap.input && type === 'input') {
-    return _react2.default.cloneElement(child, _extends({}, childPropsMap.input(child), childProps), newChildren);
+  if (child.props.children) {
+    newChildren = _react2.default.Children.map(child.props.children, function (nestedChild) {
+      return mapPropsToChild(nestedChild, childPropsMap);
+    });
   }
 
-  return Object.keys(childProps).length || newChildren ? _react2.default.cloneElement(child, childProps, newChildren) : child;
+  return childProps || newChildren ? _react2.default.cloneElement(child, childProps, newChildren) : child;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-formulize",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A simple form validation library for React.js which wires up custom, controlled inputs through a declarative API.",
   "main": "dist/index",
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-react-formulize [![Build Status](https://travis-ci.org/clocasto/react-formulize.svg?branch=master)](https://travis-ci.org/clocasto/react-formulize) [![Coverage Status](https://coveralls.io/repos/github/clocasto/react-formulize/badge.svg?branch=master&version=1_1_1)](https://coveralls.io/github/clocasto/react-formulize?branch=master&version=1_1_1)
+react-formulize [![Build Status](https://travis-ci.org/clocasto/react-formulize.svg?branch=master)](https://travis-ci.org/clocasto/react-formulize) [![Coverage Status](https://coveralls.io/repos/github/clocasto/react-formulize/badge.svg?branch=master&version=1_2_0)](https://coveralls.io/github/clocasto/react-formulize?branch=master&version=1_2_0)
 =========
 
 React-formulize is a simple form validation library for React.js which wires up custom, controlled inputs through a declarative API. The library strives to be minimal, and as such, does most component communication implicity. The end result is a legible form which clearly states the rules of its behavior.
@@ -303,6 +303,7 @@ MIT (See license.txt)
 
 ## <a href="release-history"></a>Release History
 
-* [1.1.1](https://github.com/clocasto/react-formulize/pull/35) (Current)
+* [1.2.0](https://github.com/clocasto/react-formulize/pull/38) (Current)
+* [1.1.1](https://github.com/clocasto/react-formulize/pull/35)
 * [1.1.0](https://github.com/clocasto/react-formulize/pull/32)
 * [1.0.0](https://github.com/clocasto/react-formulize/pull/25)

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ React-formulize can be used to both quickly compose forms or add validation to e
 
 #### Rules to follow:
   1. A `Form` component can wrap (nested JSX) a set of `Field` components or `input` elements (or fragments containing them) and automatically manage the state of them. All `Field`s and `input`s *must* have `name` props assigned to them.
-  2. A `Field` component can wrap (nested JSX) an `input` element (or a fragment containing an `input`) and control its underlying state automatically.
+  2. A `Field` component can wrap (nested JSX) an `input` element, a fragment containing an `input`, or a custom component flagged with a `props.input=true`, and control its underlying state automatically.
   3. Pass validator props to the `Field` components. A `Field` component will keep track of its own validity.
   4. Pass an `onSubmit` handler to `Form` in order to interact with the submission event. The callback will be passed a clone of the `Form`'s state.
   5. Pass `valid` and `pristine` props to any nested child components in either a `Form` or `Field` component. These components will receive information about the `Form`'s status in the format of `${fieldName}_${statusType}` (e.g. name_valid & email_pristine).
@@ -43,7 +43,7 @@ React-formulize can be used to both quickly compose forms or add validation to e
       <Form onSubmit={onSubmit}>
         <Field name="name_field" length={[3, 24]} />
         <Field name="age_field" required min="18" max="150">
-          <AgePickerComponent />
+          <AgePickerComponent input />
         </Field>
         <Field name="email_field" required email debounce="300">
           <label>
@@ -61,7 +61,6 @@ React-formulize can be used to both quickly compose forms or add validation to e
 ```javascript  
   import React from 'react';
   import { Field } from 'react-formulize';
-  import { AgePickerComponent } from './components/agePicker';
   
   export class RegistrationForm extends React.Component { 
     constructor(props) {
@@ -185,7 +184,7 @@ The `Field` component will behave as follows with respect to its children:
   
   1. If no components are nested in a `Field` component, a default label and input element will be used.  
   2. Any `input` tag will be passed `name`, `type`, `value`, and `onChange` props.  
-  3. If only a single direct child is passed to `Field`, it will be passed all of the relevant input props.  
+  3. Any component with an `input` flag (`props.input = true`) that is nested in a `Field` will be passed all of the relevant input props.  
   4. If multiple `input` tags are nested in a single `Field`, they would all share a single state (not recommended).  
   5. Any component with a `valid` prop will be passed a prop stating the `Field`'s validity (e.g. name_valid).  
   6. Any component with a `pristine` prop will be passed a prop stating the `Field`'s pristine state (e.g. email_pristine).  

--- a/src/helpers/utilities.jsx
+++ b/src/helpers/utilities.jsx
@@ -92,29 +92,27 @@ export function makePropsForStatus(status, state) {
 
 export function mapPropsToChild(child, childPropsMap) {
   const type = (typeof child.type === 'function') ? child.type.name : child.type;
-  const childProps = {};
+  let childProps;
   let newChildren;
 
-  if (child.props) {
-    if (childPropsMap.valid && child.props.valid) {
-      Object.assign(childProps, childPropsMap.valid());
-    }
-    if (childPropsMap.pristine && child.props.pristine) {
-      Object.assign(childProps, childPropsMap.pristine());
-    }
-    if (child.props.children) {
-      newChildren = React.Children
-        .map(child.props.children, nestedChild => mapPropsToChild(nestedChild, childPropsMap));
-    }
-  }
+  if (!child.props) return child;
 
+  if (childPropsMap.valid && child.props.valid) {
+    childProps = { ...childProps, ...childPropsMap.valid() };
+  }
+  if (childPropsMap.pristine && child.props.pristine) {
+    childProps = { ...childProps, ...childPropsMap.pristine() };
+  }
+  if (childPropsMap.input && (type === 'input' || child.props.input)) {
+    childProps = { ...childProps, ...childPropsMap.input(child) };
+  }
   if (childPropsMap.Field && type === 'Field') {
-    return React.cloneElement(child, { ...childPropsMap.Field(child), ...childProps }, newChildren);
+    childProps = { ...childProps, ...childPropsMap.Field(child) };
   }
-  if (childPropsMap.input && type === 'input') {
-    return React.cloneElement(child, { ...childPropsMap.input(child), ...childProps }, newChildren);
+  if (child.props.children) {
+    newChildren = React.Children
+      .map(child.props.children, nestedChild => mapPropsToChild(nestedChild, childPropsMap));
   }
 
-  return (Object.keys(childProps).length || newChildren) ?
-    React.cloneElement(child, childProps, newChildren) : child;
+  return (childProps || newChildren) ? React.cloneElement(child, childProps, newChildren) : child;
 }

--- a/tests/components/Field.spec.js
+++ b/tests/components/Field.spec.js
@@ -49,9 +49,10 @@ describe('<Field /> Higher-Order-Component', () => {
       expect(wrapper.find(Field)).to.have.length(1);
       expect(wrapper.find('h4')).to.have.length(1);
       expect(wrapper.find('h4').text()).to.equal('My Test Input!');
+      expect(wrapper.find('input').exists()).to.be.true; // eslint-disable-line
     });
 
-    it('passes `props` down to the custom `Input` component', () => {
+    it('passes `props` down to the nested field component', () => {
       expect(wrapper.find(Field)).to.have.length(1);
       expect(wrapper.find('h4')).to.have.length(1);
       expect(wrapper.find('h4').text()).to.equal('My Test Input!');
@@ -66,6 +67,23 @@ describe('<Field /> Higher-Order-Component', () => {
 
       expect(renderedCustomInputProps).to.have.property('onChange');
       expect(typeof renderedCustomInputProps.onChange).to.eql('function');
+    });
+
+    it('passes `props` down to the custom `Input` component flagged as input', () => {
+      const Input = () => <input />;
+      wrapper = mount(
+        <Field value={'value!'} name="test_input" onChange={onChange}>
+          <Input input />
+        </Field>);
+
+      const customInput = wrapper.find(Input);
+      expect(customInput).to.have.length(1);
+
+      const customInputProps = customInput.props();
+      expect(customInputProps).to.have.property('onChange');
+      expect(customInputProps).to.have.property('value', 'value!');
+      expect(customInputProps).to.have.property('type', 'text');
+      expect(typeof customInputProps.onChange).to.eql('function');
     });
   });
 


### PR DESCRIPTION
- Any `Field`-nested component with an `input` flag (meaning the input is passed `props.input = true`) will be passed all of the relevant input props. This allows for plugging in custom input components into a `Field`. See below:
```javascript  
<Form>
  <Field name="email">
    <CustomEmailInput input /> {/* Passed input props! */}
  </Field>
  <Field name="address">
    <CustomAddressInput /> {/* NOT passed input props! */}
  </Field>
</Form>
```